### PR TITLE
Add text query in the search query options

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.5
+current_version = 0.1.6
 commit = True
 tag = True
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ This queries are the following:
     
     `{"updatedFrequency":["monthly"]}`
 
+- text
+
+    Retrieve all the values that match with the text sent.
+    
+    `{"text":["weather"]}`
+
 ## Code style
 
 The information about code style in python is documented in this two links [python-developer-guide](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/development/python-developer-guide.md)

--- a/oceandb_mongodb_driver/__init__.py
+++ b/oceandb_mongodb_driver/__init__.py
@@ -1,4 +1,4 @@
 from oceandb_mongodb_driver import plugin
 
 __author__ = """OceanProtocol"""
-__version__ = '0.1.5'
+__version__ = '0.1.6'

--- a/oceandb_mongodb_driver/utils.py
+++ b/oceandb_mongodb_driver/utils.py
@@ -28,6 +28,8 @@ def query_parser(query):
             create_created_query(query, query_result)
         elif 'sample' in key:
             query_result[index.sample] = 'sample'
+        elif 'text' in key:
+            create_text_query(query['text'], query_result)
         else:
             logger.error('The key %s is not supported by OceanDB.' % key[0])
             raise Exception('The key %s is not supported by OceanDB.' % key[0])
@@ -72,4 +74,9 @@ def create_created_query(query, query_result):
         else:
             logger.info('The key %s is not supported in the created query' % values)
     query_result['created'] = {GT: now}
+    return query_result
+
+
+def create_text_query(query, query_result):
+    query_result['$text'] = {"$search": query[0]}
     return query_result

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/oceanprotocol/oceandb-mongodb-driver',
-    version='0.1.5',
+    version='0.1.6',
     zip_safe=False,
 )

--- a/tests/oceandb.ini
+++ b/tests/oceandb.ini
@@ -3,7 +3,7 @@
 #location of plugin class
 module=mongodb
 module.path=./oceandb_mongodb_driver/plugin.py
-db.hostname=172.15.0.11
+db.hostname=localhost
 db.port=27017
 ;db.username=travis
 ;db.password=test

--- a/tests/oceandb.ini
+++ b/tests/oceandb.ini
@@ -3,7 +3,7 @@
 #location of plugin class
 module=mongodb
 module.path=./oceandb_mongodb_driver/plugin.py
-db.hostname=localhost
+db.hostname=172.15.0.11
 db.port=27017
 ;db.username=travis
 ;db.password=test

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -56,6 +56,10 @@ def test_plugin_query():
     assert mongo.query(search_model_5).retrieved == 0
     search_model_6 = QueryModel({'created': []})
     assert mongo.query(search_model_6)[0]['id'] == ddo_sample['id']
+    search_model_7 = QueryModel({'text': ['weather']})
+    assert mongo.query(search_model_7)[0]['id'] == ddo_sample['id']
+    search_model_8 = QueryModel({'text': ['weather'], 'price': [0, 12]})
+    assert mongo.query(search_model_8)[0]['id'] == ddo_sample['id']
     mongo.delete(ddo_sample['id'])
 
 
@@ -101,12 +105,15 @@ def test_query_parser():
     query = {'categories': ['weather', 'other']}
     assert query_parser(query) == {"$or": [{"service.metadata.base.categories": "weather"},
                                            {"service.metadata.base.categories": "other"}]}
+    query = {'text': ['weather']}
+    assert query_parser(query) == {"$text": {"$search": "weather"}}
 
 
 def test_query_not_supported():
     query = {'not_supported': []}
     with pytest.raises(Exception):
         query_parser(query)
+
 
 def test_default_sort():
     mongo.write(ddo_sample, ddo_sample['id'])


### PR DESCRIPTION
## Description
Add the possibility to send the text query in the search parameters.
## Is this PR related with an open issue?

Related to Issue #https://github.com/oceanprotocol/aquarius/issues/145

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://media.giphy.com/media/k59yYusdGXlPG/giphy.gif)