### PR TITLE
add query support for tags

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.9
+current_version = 0.1.10
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 History
 =======
 
+0.1.10 (May 24th, 2019)
+-----------------------
+* Allow to search by tags.
+
 0.1.9 (April 8th, 2019)
 -----------------------
 * Fix bug in search query pagination

--- a/oceandb_mongodb_driver/__init__.py
+++ b/oceandb_mongodb_driver/__init__.py
@@ -4,4 +4,4 @@
 from oceandb_mongodb_driver import plugin
 
 __author__ = """OceanProtocol"""
-__version__ = '0.1.9'
+__version__ = '0.1.10'

--- a/oceandb_mongodb_driver/indexes.py
+++ b/oceandb_mongodb_driver/indexes.py
@@ -5,8 +5,9 @@ price = "service.metadata.base.price"
 license = "service.metadata.base.license"
 sample = "service.metadata.base.links.type"
 categories = "service.metadata.base.categories"
+tags = "service.metadata.base.tags"
 created = "created"
 updated_frequency = "service.metadata.additionalInformation.updateFrequency"
 service_type = "service.type"
 
-list_indexes = [price, license, sample, categories, created, updated_frequency, service_type]
+list_indexes = [price, license, sample, categories, tags, created, updated_frequency, service_type]

--- a/oceandb_mongodb_driver/utils.py
+++ b/oceandb_mongodb_driver/utils.py
@@ -23,6 +23,8 @@ def query_parser(query):
             create_query(query['license'], index.license, query_result, OR)
         elif 'categories' in key:
             create_query(query['categories'], index.categories, query_result, OR)
+        elif 'tags' in key:
+            create_query(query['tags'], index.tags, query_result, OR)
         elif 'type' in key:
             create_query(query['type'], index.service_type, query_result, AND)
         elif 'updateFrequency' in key:

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/oceanprotocol/oceandb-mongodb-driver',
-    version='0.1.9',
+    version='0.1.10',
     zip_safe=False,
 )

--- a/tests/ddo_example.py
+++ b/tests/ddo_example.py
@@ -294,7 +294,7 @@ ddo_sample = {
                         }
                     ],
                     "inLanguage": "en",
-                    "tags": "weather, uk, 2011, temperature, humidity",
+                    "tags": ["weather", "uk", "2011", "temperature", "humidity"],
                     "price": 10
                 },
                 "curation": {


### PR DESCRIPTION
Commons needs to be able to query for assets based on their tags in https://github.com/oceanprotocol/commons/pull/125

This PR simply adds `tags` to the list of indexes