### PR TITLE
allow querying for custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ In the configuration we are going to specify the following parameters to
     module.path=            # You can specify the location of your custom plugin.
     db.hostname=localhost   # Address of your MongoDB.
     db.port=27017           # Port of your Mongodb.
-    
+
     db.ssl=True             # If True, connections will be made using HTTPS, else using HTTP
     db.verify_certs=False   # If True, CA certificate will be verified
     db.ca_cert_path=        # If verifyCerts is True, then path to the CA cert should be provided here
     db.client_key=          # If db server needs client verification, then provide path to your client key
     db.client_cert_path=    # If db server needs client verification, then provide path to your client certificate
-   
+
     db.username=user        # If you are using authentication, mongodb username.
     db.password=password    # If you are using authentication, mongodb password.
     db.name=test            # Mongodb database name
@@ -81,9 +81,9 @@ Once you have defined this the only thing that you have to do it is use it:
 
 When you want to instantiate an Oceandb plugin you can provide the next environment variables:
 
-- **$CONFIG_PATH** 
-- **$MODULE** 
-- **$DB_HOSTNAME** 
+- **$CONFIG_PATH**
+- **$MODULE**
+- **$DB_HOSTNAME**
 - **$DB_PORT**
 - **$DB_NAME**
 - **$DB_COLLECTION**
@@ -93,71 +93,93 @@ When you want to instantiate an Oceandb plugin you can provide the next environm
 
 ## Queries
 
-Currently we are supporting a list of queries predefined in order to improve the search:
-All this queries present a common format: 
-```query:{"name":[args]}```
+You can query the DDO using predefined fields or provide the path to the desired fields yourself.
 
-This queries are the following:
+All queries use a common format:
+```json
+{
+  "query": {
+    "field": ["value1", "value2"]
+  }
+}
+```
+
+### Querying predefined fields
+
+Predefined fields include:
 - price
-    
+
     Could receive one or two parameters. If you only pass one assumes that your query is going to start from 0 to your value.
-        
+
     Next query:
     `query:{"price":[0,10]}`
-    
+
     It is transformed to:
     `{"service.metadata.base.price":{"$gt": 0, "$lt": 10}}`
-        
+
 - license
-    
-    It is going to retrieve all the documents with license that you are passing in the parameters, 
+
+    It is going to retrieve all the documents with license that you are passing in the parameters,
     if you do not pass any value retrieve all.
-        
+
     `{"license":["Public domain", "CC-YB"]}`
-    
+
 - type
-    
+
     It is going to check that the following service types are included in the ddo.
-    
+
     `{"type":["Access", "Metadata"]}`
 
 - sample
 
     Check that the metadata include a sample that contains a link of type sample. Do not take parameters.
-    
+
     `{"sample":[]}`
-    
+
 - categories
 
     Retrieve all the values that contain one of the specifies categories.
-    
+
     `{"categories":["weather", "meteorology"]}`
-    
+
 - created
 
-    Retrieve all the values that has been created after a specified date. 
+    Retrieve all the values that has been created after a specified date.
     The parameters available are 'today', 'lastWeek', 'lastMonth', 'lastYear'. If you pass more than one take the bigger interval.
     If you do not pass any parameter retrieve everything.
-    
+
     `{"created":["today"]}`
-    
+
 - updatedFrequency
 
     Retrieve all the values that contain one of the specifies updated frecuencies.
-    
+
     `{"updatedFrequency":["monthly"]}`
 
 - text
 
     Retrieve all the values that match with the text sent.
-    
+
     `{"text":["weather"]}`
+
+### Querying custom fields
+
+You can also query the DDO by value of any field. To do that, you will need to provide the full path inside the metadata instead of just the field name.
+
+For example:
+```json
+{
+  "query": {
+    "service.attributes.additionalInformation.customField": ["customValue1", "customValue2"]
+  }
+}
+```
 
 ## Code style
 
 The information about code style in python is documented in this two links [python-developer-guide](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/development/python-developer-guide.md)
 and [python-style-guide](https://github.com/oceanprotocol/dev-ocean/blob/master/doc/development/python-style-guide.md).
-    
+
 ## Testing
 
 Automatic tests are setup via Travis, executing `tox`.

--- a/oceandb_mongodb_driver/utils.py
+++ b/oceandb_mongodb_driver/utils.py
@@ -41,8 +41,7 @@ def query_parser(query):
         elif 'text' == key:
             create_text_query(query['text'], query_result)
         else:
-            logger.error('The key %s is not supported by OceanDB.' % key[0])
-            raise Exception('The key %s is not supported by OceanDB.' % key[0])
+            create_query(value, key, query_result, OR)
     return query_result
 
 

--- a/tests/ddo_example.py
+++ b/tests/ddo_example.py
@@ -312,7 +312,8 @@ ddo_sample = {
                     "size": "3.1gb",
                     "copyrightHolder": "Met Office",
                     "categories": ["weather", "meteorology"],
-                    "workExample": "423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68"
+                    "workExample": "423432fsd,51.509865,-0.118092,2011-01-01T10:55:11+00:00,7.2,68",
+                    "customField": "customValue"
                 }
             }
         }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -80,6 +80,12 @@ def test_plugin_query():
     search_model_8 = QueryModel({'text': ['weather'], 'price': ["0", "12"]})
     assert mongo.query(search_model_8)[0][0]['id'] == ddo_sample['id']
 
+    search_model_9 = QueryModel({'service.attributes.additionalInformation.customField': ['customValue']})
+    assert mongo.query(search_model_9)[0][0]['id'] == ddo_sample['id']
+
+    search_model_10 = QueryModel({'service.attributes.additionalInformation.nonExistentField': ['customValue']})
+    assert mongo.query(search_model_10)[0].retrieved == 0
+
     delete_all()
 
 
@@ -143,11 +149,8 @@ def test_query_parser():
     query = {'text': ['weather']}
     assert query_parser(query) == {"$text": {"$search": "weather"}}
 
-
-def test_query_not_supported():
-    query = {'not_supported': []}
-    with pytest.raises(Exception):
-        query_parser(query)
+    query = {'service.attributes.additionalInformation.customField': ['customValue']}
+    assert query_parser(query) == {"$or": [{"service.attributes.additionalInformation.customField": "customValue"}]}
 
 
 def test_default_sort():


### PR DESCRIPTION
## Description

Allow searching for custom fields in the metadata by passing a full field path. This also slightly changes the previous behaviour - after this change searching for a field that doesn't exist will return an empty list of results instead of throwing an error.

## Is this PR related with an open issue?

Don't think so

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation